### PR TITLE
Changed buttons

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,20 +6,16 @@ const { app, BrowserWindow, Menu, ipcMain } = require("electron");
 const isDev = false;
 const isMac = process.platform === "darwin";
 
-function editText({ folderPath, find, replace, matchCase, matchWord }) {
+function editText({ folderPath, find, replace, keepCase, processSub }) {
   let options = {
     mode: "text",
-    args: [folderPath, find, replace, matchCase, matchWord],
+    args: [folderPath, find, replace, keepCase, processSub],
   };
-  PythonShell.run("editor.py", options, function (err) {
-    console.log(err);
-  })
-    .then((message) => {
-      console.log(message);
+  PythonShell.run("editor.py", options)
+    .then(() => {
       mainWindow.webContents.send("file:done");
     })
-    .catch((err) => {
-      console.log(err);
+    .catch(() => {
       mainWindow.webContents.send("file:error");
     });
 }

--- a/renderer/css/style.css
+++ b/renderer/css/style.css
@@ -399,8 +399,6 @@ embed,
 object {
   display: block;
   /* 1 */
-  vertical-align: middle;
-  /* 2 */
 }
 
 /*

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -41,12 +41,10 @@
     <form id="text-form">
       <div class="mx-auto fit-content">
         <div class="inline-block">
-          <label for="find" class="block text-center text-white shadow-sm border-gray-300 rounded-md">Find</label>
           <textarea name="find" id="find" class="p-3 shadow-sm border-gray-300 rounded-md" rows="10" cols="30"
             placeholder="Find"></textarea>
         </div>
         <div class="inline-block">
-          <label for="replace" class="block text-center text-white shadow-sm border-gray-300 rounded-md">Replace</label>
           <textarea name="replace" id="replace" class="p-3 shadow-sm border-gray-300 rounded-md" rows="10" cols="30"
             placeholder="Replace"></textarea>
         </div>
@@ -55,21 +53,21 @@
       <div class="mx-auto fit-content">
         <div
           class="inline-block m-2 py-4 px-4 border border-transparent shadow-sm font-medium text-medium rounded-md text-white bg-teal-500 hover:bg-teal-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
-          <input type="checkbox" id="case" name="case" value="case">
-          <label for="case">&nbspMatch case</label>
+          <input type="checkbox" id="case" name="case">
+          <label for="case">&nbspKeep case</label>
         </div>
 
         <div
           class="inline-block mx-2 my-5 py-4 px-4 border border-transparent shadow-sm font-medium text-medium rounded-md text-white bg-teal-500 hover:bg-teal-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
-          <input type="checkbox" id="whole-word" name="whole-word" value="word">
-          <label for="whole-word">&nbspMatch whole word</label>
+          <input type="checkbox" id="subfolders" name="subfolders">
+          <label for="subfolders">&nbspProcess subfolders</label>
         </div>
 
         <!-- Button -->
         <div class="inline-block">
           <button type="submit"
             class="block m-2 py-4 px-4 border border-transparent shadow-sm font-medium text-medium rounded-md text-white bg-teal-500 hover:bg-teal-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
-            Edit
+            Replace All
           </button>
         </div>
       </div>

--- a/renderer/js/renderer.js
+++ b/renderer/js/renderer.js
@@ -5,7 +5,7 @@ const doc = document.querySelector("#doc");
 const replaceInput = document.querySelector("#replace");
 const findInput = document.querySelector("#find");
 const caseCheck = document.getElementById("case");
-const wordCheck = document.getElementById("whole-word");
+const processSubCheck = document.getElementById("subfolders");
 const modal = document.getElementById("modal");
 const modalHeader = document.getElementById("modal-header");
 const span = document.getElementById("close");
@@ -53,7 +53,7 @@ function reset() {
   replaceInput.value = "";
   doc.file = null;
   caseCheck.checked = false;
-  wordCheck.checked = false;
+  processSubCheck.checked = false;
   select.innerHTML = "Select a folder of files to edit";
   folderName.innerHTML = "";
 }
@@ -75,15 +75,15 @@ function editText(e) {
   const folderPath = getFolderPath();
   const find = findInput.value;
   const replace = replaceInput.value;
-  const matchCase = caseCheck.checked;
-  const matchWord = wordCheck.checked;
+  const keepCase = caseCheck.checked;
+  const processSub = processSubCheck.checked;
 
   ipcRenderer.send("file:edit", {
     folderPath,
     find,
     replace,
-    matchCase,
-    matchWord,
+    keepCase,
+    processSub,
   });
 }
 


### PR DESCRIPTION
Added buttons to keep case (ex: find and replace "persons" to "people" would edit "Persons" to "People", "PERSONS" to "PEOPLE", or "persons" to "people"), process subfolders, and removed the buttons for match case and match word. Match case is a little irrelevant because of keep case, and match word is now done automatically.